### PR TITLE
add a task to check for warnings and fail if there were any

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,40 @@ If `continueOn` is called muliple times `continueOff` must be called that many t
 
 If `continueOff` is called more times than `continueOn` it will fail.
 
+### Checking to see if there were any failures within the block
+
+It is sometimes useful to check if there were any warnings issued by any tasks within `continueOn` and `continueOff`. 
+For example, you may run a test within the block and cleanup at the end. In this instance you want the overall build to fail after the cleanup.
+
+To accommodate this add the following task at the end: 
+
+```javascript
+module.exports = function(grunt) {
+
+  // Add the grunt-continue tasks
+  grunt.loadNpmTasks('grunt-continue');
+
+  // Other tasks and configuration
+  ...
+
+  grunt.registerTask('default', [
+    'setup',
+    'continueOn',
+    // All tasks after this point will be run with the force
+    // option so that grunt will continue after failures
+    'test',
+    'continueOff',
+    // Tasks after this point will be run without the force
+    // option so that grunt exits if they fail
+    'cleanup',
+    'continueFailIfWarningsWereIssued'
+  ]);
+
+};
+  
+  grun
+```
+
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using: 
 

--- a/tasks/continue.js
+++ b/tasks/continue.js
@@ -1,5 +1,15 @@
 module.exports = function(grunt) {
+
+  var defaultWarnHandler = grunt.fail.warn;
+
+  function warn(){
+    grunt.config.set('grunt-continue:warning-issued', true);
+    defaultWarnHandler.apply(grunt, Array.prototype.slice.call(arguments));
+  }
+
   grunt.registerTask('continueOn', 'Continue after failing tasks', function() {
+
+    grunt.fail.warn = warn;
     overridden = grunt.config('grunt-continue:overridden') || false;
     if (!overridden) {
       count = grunt.config('grunt-continue:count') || 0;
@@ -15,6 +25,7 @@ module.exports = function(grunt) {
   });
 
   grunt.registerTask('continueOff', 'Stop continuing after failing tasks', function() {
+    grunt.fail.warn = defaultWarnHandler;
     overridden = grunt.config('grunt-continue:overridden') || false;
     if (!overridden) {
       count = grunt.config('grunt-continue:count') || 0;
@@ -23,6 +34,13 @@ module.exports = function(grunt) {
       if (!count) {
         grunt.option('force', false);
       }
+    }
+  });
+
+  grunt.registerTask('continueFailIfWarningsWereIssued', 'Check to see if there were any failures', function(){
+    var warningWasIssued = grunt.config('grunt-continue:warning-issued') || false;
+    if(warningWasIssued) {
+      grunt.fail.warn('A warning was issued within a continueOn <-> continueOff block');
     }
   });
 };

--- a/test/scenarios/failIfWarningsWereIssued/Gruntfile.js
+++ b/test/scenarios/failIfWarningsWereIssued/Gruntfile.js
@@ -1,0 +1,22 @@
+module.exports = function(grunt) {
+  // Add our custom tasks.
+  grunt.loadTasks('../../../tasks');
+
+  grunt.registerTask('fail', function(label) {
+    grunt.log.writeln(label);
+    return false;
+  });
+
+  grunt.registerTask('pass', function(label) {
+    grunt.log.writeln(label);
+    return true;
+  });
+
+  // Default task.
+  grunt.registerTask('default', [
+    'continueOn',
+    'fail:second',
+    'continueOff',
+    'continueFailIfWarningsWereIssued'
+  ]);
+};

--- a/test/scenarios/passIfNoWarningsWereIssued/Gruntfile.js
+++ b/test/scenarios/passIfNoWarningsWereIssued/Gruntfile.js
@@ -1,0 +1,22 @@
+module.exports = function(grunt) {
+  // Add our custom tasks.
+  grunt.loadTasks('../../../tasks');
+
+  grunt.registerTask('fail', function(label) {
+    grunt.log.writeln(label);
+    return false;
+  });
+
+  grunt.registerTask('pass', function(label) {
+    grunt.log.writeln(label);
+    return true;
+  });
+
+  // Default task.
+  grunt.registerTask('default', [
+    'continueOn',
+    'pass:first',
+    'continueOff',
+    'continueFailIfWarningsWereIssued'
+  ]);
+};

--- a/test/tasks/grunt-continue.js
+++ b/test/tasks/grunt-continue.js
@@ -46,6 +46,7 @@ var execScenario = function(scenario, force, callback) {
 };
 
 describe('grunt-continue', function() {
+
   it('should continue when continue is on and fail after continue is turned off', function(done) {
     execScenario('onOff', false, function(error, stdout, stderr) {
       expect(stdout).to.match(/first/);
@@ -91,6 +92,7 @@ describe('grunt-continue', function() {
       done();
     });
   });
+  
 
   it('should fail if continueOff is called more times than continueOn', function(done) {
     execScenario('tooManyOffs', false, function(error, stdout, stderr) {
@@ -103,4 +105,21 @@ describe('grunt-continue', function() {
       done();
     });
   });
+
+  it('should fail if we check if warnings were issued within a continue block', function(done){
+    execScenario('failIfWarningsWereIssued', false, function(error, stdout, stderr) {
+      expect(stdout).to.match(/second/);
+      expect(stdout).to.match(/Aborted due to warnings./);
+      done();
+    });
+  });
+
+  it('should pass if we check if warnings were issued within a continue block - and none were', function(done){
+    execScenario('passIfNoWarningsWereIssued', false, function(error, stdout, stderr) {
+      expect(stdout).to.match(/first/);
+      expect(stdout).to.not.match(/Aborted due to warnings./);
+      done();
+    });
+  });
+
 });


### PR DESCRIPTION
We use grunt continue to run some tests and clean up the db no matter what. However we want the overall run to fail so that we are notified. 

To fix this I've added an optional task: `continueFailIfWarningsWereIssued` that you can add to the end of a run, if any warnings were issued the task will be aborted and you'll get `6` as your exit code.
