### PR TITLE
Changing naming convention, fixing bug with grunt.warn, adding better warning message

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ module.exports = function(grunt) {
 
   grunt.registerTask('default', [
     'setup',
-    'continueOn',
+    'continue:on',
     // All tasks after this point will be run with the force
     // option so that grunt will continue after failures
     'test',
-    'continueOff',
+    'continue:off',
     // Tasks after this point will be run without the force
     // option so that grunt exits if they fail
     'cleanup'
@@ -41,15 +41,15 @@ module.exports = function(grunt) {
 };
 ```
 
-`continueOff` does not turn off the continuing if `--force` was specified at the command line.
+`continue:off` does not turn off the continuing if `--force` was specified at the command line.
 
-If `continueOn` is called muliple times `continueOff` must be called that many times in order to stop continuing.
+If `continue:on` is called muliple times `continue:off` must be called that many times in order to stop continuing.
 
-If `continueOff` is called more times than `continueOn` it will fail.
+If `continue:off` is called more times than `continue:on` it will fail.
 
 ### Checking to see if there were any failures within the block
 
-It is sometimes useful to check if there were any warnings issued by any tasks within `continueOn` and `continueOff`. 
+It is sometimes useful to check if there were any warnings issued by any tasks within `continue:on` and `continue:off`. 
 For example, you may run a test within the block and cleanup at the end. In this instance you want the overall build to fail after the cleanup.
 
 To accommodate this add the following task at the end: 
@@ -65,15 +65,15 @@ module.exports = function(grunt) {
 
   grunt.registerTask('default', [
     'setup',
-    'continueOn',
+    'continue:on',
     // All tasks after this point will be run with the force
     // option so that grunt will continue after failures
     'test',
-    'continueOff',
+    'continue:off',
     // Tasks after this point will be run without the force
     // option so that grunt exits if they fail
     'cleanup',
-    'continueFailIfWarningsWereIssued'
+    'continue:fail-on-warning'
   ]);
 
 };

--- a/tasks/continue.js
+++ b/tasks/continue.js
@@ -3,11 +3,13 @@ module.exports = function(grunt) {
   var defaultWarnHandler = grunt.fail.warn;
 
   function warn(){
-    grunt.config.set('grunt-continue:warning-issued', true);
+    var warnings = grunt.config('grunt-continue:warnings') || [];
+    warnings.push(arguments);
+    grunt.config.set('grunt-continue:warnings', warnings);
     defaultWarnHandler.apply(grunt, Array.prototype.slice.call(arguments));
   }
 
-  grunt.registerTask('continueOn', 'Continue after failing tasks', function() {
+  grunt.registerTask('continue:on', 'Continue after failing tasks', function() {
 
     grunt.fail.warn = warn;
     overridden = grunt.config('grunt-continue:overridden') || false;
@@ -24,7 +26,7 @@ module.exports = function(grunt) {
     }
   });
 
-  grunt.registerTask('continueOff', 'Stop continuing after failing tasks', function() {
+  grunt.registerTask('continue:off', 'Stop continuing after failing tasks', function() {
     grunt.fail.warn = defaultWarnHandler;
     overridden = grunt.config('grunt-continue:overridden') || false;
     if (!overridden) {
@@ -37,10 +39,14 @@ module.exports = function(grunt) {
     }
   });
 
-  grunt.registerTask('continueFailIfWarningsWereIssued', 'Check to see if there were any failures', function(){
-    var warningWasIssued = grunt.config('grunt-continue:warning-issued') || false;
-    if(warningWasIssued) {
-      grunt.fail.warn('A warning was issued within a continueOn <-> continueOff block');
+  grunt.registerTask('continue:fail-on-warning', 'Check to see if there were any warnings, fail if there were', function(){
+    var warnings = grunt.config('grunt-continue:warnings') || null;
+    if(warnings) {
+        var msg = grunt.util.pluralize(warnings.length, 'A warning has/Warnings have')+' occurred between continue:on and continue:off:\n';
+        for(var i = 0, len = warnings.length; i<len; i++) {
+            msg += ' - '+JSON.stringify(warnings[i])+'\n';
+        }
+      grunt.warn(grunt.util.normalizelf(msg));
     }
   });
 };

--- a/tasks/continue.js
+++ b/tasks/continue.js
@@ -10,8 +10,7 @@ module.exports = function(grunt) {
   }
 
   grunt.registerTask('continue:on', 'Continue after failing tasks', function() {
-
-    grunt.fail.warn = warn;
+    grunt.warn = grunt.fail.warn = warn;
     overridden = grunt.config('grunt-continue:overridden') || false;
     if (!overridden) {
       count = grunt.config('grunt-continue:count') || 0;
@@ -27,7 +26,7 @@ module.exports = function(grunt) {
   });
 
   grunt.registerTask('continue:off', 'Stop continuing after failing tasks', function() {
-    grunt.fail.warn = defaultWarnHandler;
+    grunt.warn = grunt.fail.warn = defaultWarnHandler;
     overridden = grunt.config('grunt-continue:overridden') || false;
     if (!overridden) {
       count = grunt.config('grunt-continue:count') || 0;

--- a/tasks/continue.js
+++ b/tasks/continue.js
@@ -1,51 +1,54 @@
 module.exports = function(grunt) {
 
-  var defaultWarnHandler = grunt.fail.warn;
+    var defaultWarnHandler = grunt.fail.warn;
 
-  function warn(){
-    var warnings = grunt.config('grunt-continue:warnings') || [];
-    warnings.push(arguments);
-    grunt.config.set('grunt-continue:warnings', warnings);
-    defaultWarnHandler.apply(grunt, Array.prototype.slice.call(arguments));
-  }
+    function warn(){
+        var warnings = grunt.config('grunt-continue:warnings') || [];
+        warnings.push(arguments[0]);
+        grunt.config.set('grunt-continue:warnings', warnings);
+        defaultWarnHandler.apply(grunt, Array.prototype.slice.call(arguments));
+    }
 
-  grunt.registerTask('continue:on', 'Continue after failing tasks', function() {
-    grunt.warn = grunt.fail.warn = warn;
-    overridden = grunt.config('grunt-continue:overridden') || false;
-    if (!overridden) {
-      count = grunt.config('grunt-continue:count') || 0;
-      if (!count && grunt.option('force')) {
-        grunt.config('grunt-continue:overridden', true);
-      } else {
-        if (!count) {
-          grunt.option('force', true);
+    grunt.registerTask('continue:on', 'Continue after failing tasks', function() {
+        grunt.warn = grunt.fail.warn = warn;
+        overridden = grunt.config('grunt-continue:overridden') || false;
+        if (!overridden) {
+            count = grunt.config('grunt-continue:count') || 0;
+            if (!count && grunt.option('force')) {
+                grunt.config('grunt-continue:overridden', true);
+            } else {
+                if (!count) {
+                    grunt.option('force', true);
+                }
+                grunt.config.set('grunt-continue:count', ++count);
+            }
         }
-        grunt.config.set('grunt-continue:count', ++count);
-      }
-    }
-  });
+    });
 
-  grunt.registerTask('continue:off', 'Stop continuing after failing tasks', function() {
-    grunt.warn = grunt.fail.warn = defaultWarnHandler;
-    overridden = grunt.config('grunt-continue:overridden') || false;
-    if (!overridden) {
-      count = grunt.config('grunt-continue:count') || 0;
-      if (!count) return false;
-      grunt.config.set('grunt-continue:count', --count);
-      if (!count) {
-        grunt.option('force', false);
-      }
-    }
-  });
-
-  grunt.registerTask('continue:fail-on-warning', 'Check to see if there were any warnings, fail if there were', function(){
-    var warnings = grunt.config('grunt-continue:warnings') || null;
-    if(warnings) {
-        var msg = grunt.util.pluralize(warnings.length, 'A warning has/Warnings have')+' occurred between continue:on and continue:off:\n';
-        for(var i = 0, len = warnings.length; i<len; i++) {
-            msg += ' - '+JSON.stringify(warnings[i])+'\n';
+    grunt.registerTask('continue:off', 'Stop continuing after failing tasks', function() {
+        grunt.warn = grunt.fail.warn = defaultWarnHandler;
+        overridden = grunt.config('grunt-continue:overridden') || false;
+        if (!overridden) {
+            count = grunt.config('grunt-continue:count') || 0;
+            if (!count) return false;
+            grunt.config.set('grunt-continue:count', --count);
+            if (!count) {
+                grunt.option('force', false);
+            }
         }
-      grunt.warn(grunt.util.normalizelf(msg));
-    }
-  });
+    });
+
+    grunt.registerTask('continue:fail-on-warning', 'Check to see if there were any warnings, fail if there were', function(){
+        var warnings = grunt.config('grunt-continue:warnings') || null;
+        if(warnings) {
+            var msg = grunt.util.pluralize(warnings.length, 'A warning has/Warnings have')+' occurred between continue:on and continue:off:\n';
+            for(var i = 0, len = warnings.length; i<len; i++) {
+                msg += ' - ';
+                msg += grunt.util.kindOf(warnings[i]) == 'string'?warnings[i]:JSON.stringify(warnings[i]);
+                msg += '\n';
+            }
+            msg += '\n';
+            grunt.warn(grunt.util.normalizelf(msg));
+        }
+    });
 };

--- a/test/scenarios/failIfWarningsWereIssued/Gruntfile.js
+++ b/test/scenarios/failIfWarningsWereIssued/Gruntfile.js
@@ -14,9 +14,9 @@ module.exports = function(grunt) {
 
   // Default task.
   grunt.registerTask('default', [
-    'continueOn',
+    'continue:on',
     'fail:second',
-    'continueOff',
-    'continueFailIfWarningsWereIssued'
+    'continue:off',
+    'continue:fail-on-warning'
   ]);
 };

--- a/test/scenarios/nestedOnOff/Gruntfile.js
+++ b/test/scenarios/nestedOnOff/Gruntfile.js
@@ -15,15 +15,15 @@ module.exports = function(grunt) {
   // Default task.
   grunt.registerTask('default', [
     'pass:first',
-    'continueOn',
-    'continueOn',
-    'continueOn',
+    'continue:on',
+    'continue:on',
+    'continue:on',
     'fail:second',
-    'continueOff',
+    'continue:off',
     'fail:third',
-    'continueOff',
+    'continue:off',
     'fail:fourth',
-    'continueOff',
+    'continue:off',
     'fail:fifth',
     'pass:sixth'
   ]);

--- a/test/scenarios/onOff/Gruntfile.js
+++ b/test/scenarios/onOff/Gruntfile.js
@@ -14,9 +14,9 @@ module.exports = function(grunt) {
 
   grunt.registerTask('default', [
     'pass:first',
-    'continueOn',
+    'continue:on',
     'fail:second',
-    'continueOff',
+    'continue:off',
     'fail:third',
     'pass:fourth'
   ]);

--- a/test/scenarios/onOffWithFailFirst/Gruntfile.js
+++ b/test/scenarios/onOffWithFailFirst/Gruntfile.js
@@ -15,9 +15,9 @@ module.exports = function(grunt) {
   // Default task.
   grunt.registerTask('default', [
     'fail:first',
-    'continueOn',
+    'continue:on',
     'fail:second',
-    'continueOff',
+    'continue:off',
     'pass:third',
     'pass:fourth'
   ]);

--- a/test/scenarios/passIfNoWarningsWereIssued/Gruntfile.js
+++ b/test/scenarios/passIfNoWarningsWereIssued/Gruntfile.js
@@ -14,9 +14,9 @@ module.exports = function(grunt) {
 
   // Default task.
   grunt.registerTask('default', [
-    'continueOn',
+    'continue:on',
     'pass:first',
-    'continueOff',
-    'continueFailIfWarningsWereIssued'
+    'continue:off',
+    'continue:fail-on-warning'
   ]);
 };

--- a/test/scenarios/tooManyOffs/Gruntfile.js
+++ b/test/scenarios/tooManyOffs/Gruntfile.js
@@ -15,14 +15,14 @@ module.exports = function(grunt) {
   // Default task.
   grunt.registerTask('default', [
     'pass:first',
-    'continueOn',
-    'continueOn',
+    'continue:on',
+    'continue:on',
     'fail:second',
-    'continueOff',
+    'continue:off',
     'fail:third',
-    'continueOff',
+    'continue:off',
     'pass:fourth',
-    'continueOff',
+    'continue:off',
     'pass:fifth'
   ]);
 };

--- a/test/tasks/grunt-continue.js
+++ b/test/tasks/grunt-continue.js
@@ -80,7 +80,7 @@ describe('grunt-continue', function() {
     });
   });
 
-  it('should only stop continuing if continueOff has been called as many times as continueOn', function(done) {
+  it('should only stop continuing if continue:off has been called as many times as continue:on', function(done) {
     execScenario('nestedOnOff', false, function(error, stdout, stderr) {
       expect(stdout).to.match(/first/);
       expect(stdout).to.match(/second/);
@@ -94,7 +94,7 @@ describe('grunt-continue', function() {
   });
   
 
-  it('should fail if continueOff is called more times than continueOn', function(done) {
+  it('should fail if continue:off is called more times than continue:on', function(done) {
     execScenario('tooManyOffs', false, function(error, stdout, stderr) {
       expect(stdout).to.match(/first/);
       expect(stdout).to.match(/second/);


### PR DESCRIPTION
There was an issue when using grunt.warn since it would circumvent the default warn handler grunt.fail.warn since grunt.warn would still have a reference to the original function.  I have since updated both references when using continue:on.

I've changed the naming convention since they weren't very "grunt like" and reduced down the name of the warning check.  I've updated the tests to reflect this.

Finally, I've made it so that the plugin records what were the warnings that were thrown and display then when checking in the best way I could.
