### PR TITLE
Add sub-tasks check-any-warnings, check-warnings and clear-warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/pghalliday/grunt-continue.png)](https://travis-ci.org/pghalliday/grunt-continue)
 [![Dependency Status](https://gemnasium.com/pghalliday/grunt-continue.png)](https://gemnasium.com/pghalliday/grunt-continue)
 
-A grunt plugin to force other tasks to continue after failures
+A grunt plugin to force other tasks to continue after failures and check for warnings issued after them
 
 Inspired by and extended from [this](http://stackoverflow.com/a/16972894/2622241) answer by [explunit](http://stackoverflow.com/users/151212/explunit) on StackOverflow
 
@@ -47,9 +47,9 @@ If `continue:on` is called muliple times `continue:off` must be called that many
 
 If `continue:off` is called more times than `continue:on` it will fail.
 
-### Checking to see if there were any failures within the block
+### Checking to see if there were no failures within the block
 
-It is sometimes useful to check if there were any warnings issued by any tasks within `continue:on` and `continue:off`. 
+It is sometimes useful to check if there were no warnings issued by any tasks within `continue:on` and `continue:off`.
 For example, you may run a test within the block and cleanup at the end. In this instance you want the overall build to fail after the cleanup.
 
 To accommodate this add the following task at the end: 
@@ -77,8 +77,126 @@ module.exports = function(grunt) {
   ]);
 
 };
-  
-  grun
+```
+
+### Checking to see if there were any failures within the block
+
+When you write unit tests for Grunt tasks, sometimes you need to test, that a failure was handled properly. You do not want the overall build to fail after a failing tasks did. You actually want the build to fail, if the task *did not fail*. You can achieve this by executing the `continue:check-any-warnings` task, once the continuation block ended:
+
+```javascript
+module.exports = function(grunt) {
+
+  // Add the grunt-continue tasks
+  grunt.loadNpmTasks('grunt-continue');
+
+  // Other tasks and configuration
+  ...
+
+  grunt.registerTask('default', [
+    // Tasks, which should succeed preparing output for unit test checks
+    'move:rename',
+    ...
+    // Prefent Grunt from failing, if a task fails from know on
+    'continue:on',
+    // Tasks, which should intentionally fail
+    'move:failed_wrong_path',
+    ...
+    // Allow Grunt to fail, if a task fails from know on
+    'continue:off',
+    // Check, that the tasks, which should fail, actually failed
+    'continue:check-any-warnings',
+    // Check ouput of the succeeding tasks
+    'nodeunit'
+  ]);
+
+};
+```
+
+### Checking to see if there were only specific failures within the block
+
+When you write unit tests for Grunt tasks, sometimes you need to test, that a failure was reported properly. You want the build to fail, if the failure was *not* reported, or if the expected warning was not issued. You can achieve this by configuring the `continue:check-warnings` task and by executing it, once the continuation block ended:
+
+```javascript
+module.exports = function(grunt) {
+
+  grunt.initConfig({
+    'continue:check-warnings': {
+      test: {
+        warnings: [
+          'No files or directories specified.',
+          'Moving failed.',
+          ...
+        ]
+      }
+    },
+    ...
+  });
+
+  grunt.loadNpmTasks('grunt-continue');
+  ...
+
+  grunt.registerTask('default', [
+    'move:rename',
+    ...
+    'continue:on',
+    'move:failed_missing_source',
+    'move:failed_invalid_destination',
+    ...
+    'continue:off',
+    // Check if all specified warnings were issued
+    'continue:check-warnings',
+    'nodeunit'
+  ]);
+
+};
+```
+
+### Clearing warnings before another block is entered
+
+If you use multiple `continue:on` and `continue:off` blocks of tasks, you may need to check, if a warning was issued by any task only in one specific block. It is useful, if you check for occurrences of warnings by `continue:check-any-warnings` or by `continue:check-warnings`. You can achieve this by executing the `continue:clear-warnings` task before the continuation block is entered:
+
+```javascript
+module.exports = function(grunt) {
+
+  grunt.initConfig({
+    'continue:check-warnings': {
+      second_tests: {
+        warnings: [
+          'No files or directories specified.',
+          'Moving failed.'
+        ]
+      }
+    },
+    ...
+  });
+
+  grunt.loadNpmTasks('grunt-continue');
+  ...
+
+  grunt.registerTask('default', [
+    'move:rename',
+    ...
+
+    // Check if the task fails
+    'continue:on',
+    'move:missing_task_settings',
+    'continue:off',
+    'continue:check-any-warnings',
+
+    // Make sure, tha the next check will start with no remembered warnings
+    'continue:clear-warnings',
+
+    // Check if the tasks fail and issue specified warnings
+    'continue:on',
+    'move:failed_missing_source',
+    'move:failed_invalid_destination',
+    'continue:off',
+    'continue:check-warnings:second_tests',
+
+    'nodeunit'
+  ]);
+
+};
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ module.exports = function(grunt) {
     // Tasks, which should succeed preparing output for unit test checks
     'move:rename',
     ...
-    // Prefent Grunt from failing, if a task fails from know on
+    // Prevent Grunt from failing, if a task fails from know on
     'continue:on',
     // Tasks, which should intentionally fail
     'move:failed_wrong_path',

--- a/tasks/continue.js
+++ b/tasks/continue.js
@@ -51,4 +51,51 @@ module.exports = function(grunt) {
             grunt.warn(grunt.util.normalizelf(msg));
         }
     });
+
+    grunt.registerTask('continue:clear-warnings', 'Clear warnings remembered, when continung after failing tasks was on', function() {
+        grunt.config.set('grunt-continue:warnings', null);
+        grunt.verbose.writeln('Warnings were cleared.');
+    });
+
+    grunt.registerTask('continue:check-any-warnings', 'Check to see if there were any warnings, fail if there were none', function () {
+        var actual = grunt.config('grunt-continue:warnings') || [];
+        grunt.verbose.writeln('Some warnings were expected.');
+        if (actual.length) {
+            grunt.verbose.writeln(actual.length + ' actual ' + grunt.util.pluralize(actual.length, 'warning/warnings') + ':');
+            actual.forEach(function (warning) {
+                grunt.verbose.writeln('  "' + warning + '"');
+            });
+            grunt.log.ok(actual.length + grunt.util.pluralize(actual.length, ' warning was/ warnings were') + ' found.');
+        } else {
+            grunt.fail.warn('No warnings were found.');
+        }
+    });
+
+    grunt.registerMultiTask('continue:check-warnings', 'Check to see if there were only expected warnings, fail if there were other or none', function () {
+          var expected = this.data.warnings,
+              actual = grunt.config('grunt-continue:warnings') || [];
+          if (!expected) {
+              grunt.fail.warn('No expected warnings were specified.');
+          }
+          grunt.verbose.writeln(expected.length + grunt.util.pluralize(expected.length, ' warning was/ warnings were') + ' expected:');
+          expected.forEach(function (warning) {
+              grunt.verbose.writeln('  "' + warning + '"');
+          });
+          actual = actual.map(function (warning) {
+            return warning.toString();
+          });
+          actual.forEach(function (warning) {
+              grunt.verbose.writeln('Actual warning: "' + warning + '".');
+              if (expected.indexOf(warning) < 0) {
+                  grunt.fail.warn('Unexpected warning: "' + warning + '".');
+              }
+          });
+          expected.forEach(function (warning) {
+              if (actual.indexOf(warning) < 0) {
+                  grunt.fail.warn('Warning not found: "' + warning + '".');
+              }
+          });
+          grunt.log.ok(actual.length + grunt.util.pluralize(actual.length, ' warning was/ warnings were') + ' expected and found.');
+        });
+
 };

--- a/test/scenarios/clearWarnings/Gruntfile.js
+++ b/test/scenarios/clearWarnings/Gruntfile.js
@@ -1,0 +1,23 @@
+module.exports = function(grunt) {
+  // Add our custom tasks.
+  grunt.loadTasks('../../../tasks');
+
+  grunt.registerTask('fail', function(label) {
+    grunt.log.writeln(label);
+    return false;
+  });
+
+  grunt.registerTask('pass', function(label) {
+    grunt.log.writeln(label);
+    return true;
+  });
+
+  // Default task.
+  grunt.registerTask('default', [
+    'continue:on',
+    'fail:second',
+    'continue:off',
+    'continue:clear-warnings',
+    'continue:fail-on-warning'
+  ]);
+};

--- a/test/scenarios/failIfNoWarningsWereIssued/Gruntfile.js
+++ b/test/scenarios/failIfNoWarningsWereIssued/Gruntfile.js
@@ -1,0 +1,22 @@
+module.exports = function(grunt) {
+  // Add our custom tasks.
+  grunt.loadTasks('../../../tasks');
+
+  grunt.registerTask('fail', function(label) {
+    grunt.log.writeln(label);
+    return false;
+  });
+
+  grunt.registerTask('pass', function(label) {
+    grunt.log.writeln(label);
+    return true;
+  });
+
+  // Default task.
+  grunt.registerTask('default', [
+    'continue:on',
+    'pass:first',
+    'continue:off',
+    'continue:check-any-warnings'
+  ]);
+};

--- a/test/scenarios/failIfNotAllExpectedWarningsWereIssued/Gruntfile.js
+++ b/test/scenarios/failIfNotAllExpectedWarningsWereIssued/Gruntfile.js
@@ -1,0 +1,33 @@
+module.exports = function(grunt) {
+  // Add our custom tasks.
+  grunt.loadTasks('../../../tasks');
+
+  grunt.registerTask('fail', function(label) {
+    grunt.log.writeln(label);
+    return false;
+  });
+
+  grunt.registerTask('pass', function(label) {
+    grunt.log.writeln(label);
+    return true;
+  });
+
+  grunt.initConfig({
+    'continue:check-warnings': {
+      test: {
+        warnings: [
+          'Error: Task "fail:first" failed.',
+          'Error: Task "fail:second" failed.'
+        ]
+      }
+    },
+  });
+
+  // Default task.
+  grunt.registerTask('default', [
+    'continue:on',
+    'fail:second',
+    'continue:off',
+    'continue:check-warnings'
+  ]);
+};

--- a/test/scenarios/failIfUnexpectedWarningsWereIssued/Gruntfile.js
+++ b/test/scenarios/failIfUnexpectedWarningsWereIssued/Gruntfile.js
@@ -1,0 +1,32 @@
+module.exports = function(grunt) {
+  // Add our custom tasks.
+  grunt.loadTasks('../../../tasks');
+
+  grunt.registerTask('fail', function(label) {
+    grunt.log.writeln(label);
+    return false;
+  });
+
+  grunt.registerTask('pass', function(label) {
+    grunt.log.writeln(label);
+    return true;
+  });
+
+  grunt.initConfig({
+    'continue:check-warnings': {
+      test: {
+        warnings: [
+          'Error: Task "fail:first" failed.'
+        ]
+      }
+    },
+  });
+
+  // Default task.
+  grunt.registerTask('default', [
+    'continue:on',
+    'fail:second',
+    'continue:off',
+    'continue:check-warnings'
+  ]);
+};

--- a/test/scenarios/missingExpectedWarnings/Gruntfile.js
+++ b/test/scenarios/missingExpectedWarnings/Gruntfile.js
@@ -1,0 +1,28 @@
+module.exports = function(grunt) {
+  // Add our custom tasks.
+  grunt.loadTasks('../../../tasks');
+
+  grunt.registerTask('fail', function(label) {
+    grunt.log.writeln(label);
+    return false;
+  });
+
+  grunt.registerTask('pass', function(label) {
+    grunt.log.writeln(label);
+    return true;
+  });
+
+  grunt.initConfig({
+    'continue:check-warnings': {
+      test: {}
+    },
+  });
+
+  // Default task.
+  grunt.registerTask('default', [
+    'continue:on',
+    'fail:second',
+    'continue:off',
+    'continue:check-warnings'
+  ]);
+};

--- a/test/scenarios/passIfAnyWarningsWereIssued/Gruntfile.js
+++ b/test/scenarios/passIfAnyWarningsWereIssued/Gruntfile.js
@@ -1,0 +1,22 @@
+module.exports = function(grunt) {
+  // Add our custom tasks.
+  grunt.loadTasks('../../../tasks');
+
+  grunt.registerTask('fail', function(label) {
+    grunt.log.writeln(label);
+    return false;
+  });
+
+  grunt.registerTask('pass', function(label) {
+    grunt.log.writeln(label);
+    return true;
+  });
+
+  // Default task.
+  grunt.registerTask('default', [
+    'continue:on',
+    'fail:second',
+    'continue:off',
+    'continue:check-any-warnings'
+  ]);
+};

--- a/test/scenarios/passIfConcreteWarningsWereIssued/Gruntfile.js
+++ b/test/scenarios/passIfConcreteWarningsWereIssued/Gruntfile.js
@@ -1,0 +1,32 @@
+module.exports = function(grunt) {
+  // Add our custom tasks.
+  grunt.loadTasks('../../../tasks');
+
+  grunt.registerTask('fail', function(label) {
+    grunt.log.writeln(label);
+    return false;
+  });
+
+  grunt.registerTask('pass', function(label) {
+    grunt.log.writeln(label);
+    return true;
+  });
+
+  grunt.initConfig({
+    'continue:check-warnings': {
+      test: {
+        warnings: [
+          'Error: Task "fail:second" failed.'
+        ]
+      }
+    },
+  });
+
+  // Default task.
+  grunt.registerTask('default', [
+    'continue:on',
+    'fail:second',
+    'continue:off',
+    'continue:check-warnings'
+  ]);
+};

--- a/test/tasks/grunt-continue.js
+++ b/test/tasks/grunt-continue.js
@@ -122,4 +122,60 @@ describe('grunt-continue', function() {
     });
   });
 
+  it('should be able to clear warnings before another continue block is entered', function(done){
+    execScenario('clearWarnings', false, function(error, stdout, stderr) {
+      expect(stdout).to.match(/second/);
+      expect(stdout).to.not.match(/Aborted due to warnings./);
+      done();
+    });
+  });
+
+  it('should pass if we expect any warnings to be issued within a continue block', function(done){
+    execScenario('passIfAnyWarningsWereIssued', false, function(error, stdout, stderr) {
+      expect(stdout).to.match(/second/);
+      expect(stdout).to.not.match(/Aborted due to warnings./);
+      done();
+    });
+  });
+
+  it('should fail if we expect any warnings to be issued within a continue block - and none were', function(done){
+    execScenario('failIfNoWarningsWereIssued', false, function(error, stdout, stderr) {
+      expect(stdout).to.match(/first/);
+      expect(stdout).to.match(/Aborted due to warnings./);
+      done();
+    });
+  });
+
+  it('should fail if no expected warnings were specified', function(done){
+    execScenario('missingExpectedWarnings', false, function(error, stdout, stderr) {
+      expect(stdout).to.match(/second/);
+      expect(stdout).to.match(/Aborted due to warnings./);
+      done();
+    });
+  });
+
+  it('should pass if we expect concrete warnings to be issued within a continue block', function(done){
+    execScenario('passIfConcreteWarningsWereIssued', false, function(error, stdout, stderr) {
+      expect(stdout).to.match(/second/);
+      expect(stdout).to.not.match(/Aborted due to warnings./);
+      done();
+    });
+  });
+
+  it('should fail if other than expected warnings were issued', function(done){
+    execScenario('failIfUnexpectedWarningsWereIssued', false, function(error, stdout, stderr) {
+      expect(stdout).to.match(/second/);
+      expect(stdout).to.match(/Aborted due to warnings./);
+      done();
+    });
+  });
+
+  it('should fail if not all expected warnings were issued', function(done){
+    execScenario('failIfNotAllExpectedWarningsWereIssued', false, function(error, stdout, stderr) {
+      expect(stdout).to.match(/second/);
+      expect(stdout).to.match(/Aborted due to warnings./);
+      done();
+    });
+  });
+
 });


### PR DESCRIPTION
This PR fixes #3.

The task continue:check-any-warnings does the opposite of
continue:continue:fail-on-warning. It fails, if there was no warning
issued.

The multi-task continue:check-warnings fails, if there was no warning
issued, or if there were other warnings issued, than specified for the
task.

The task continue:clear-warnings clears the warnings, which have been
remembered in the continuation blocks so far.